### PR TITLE
fix: Use 'readobj::read.obj()' as backup for 'rgl::readOBJ()'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     gridpattern,
     magick,
     rayrender (>= 0.5.8),
-    readobj,
+    readobj (>= 0.4.0),
     rgl (>= 0.106.8),
     testthat,
     vdiffr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     gridpattern,
     magick,
     rayrender (>= 0.5.8),
+    readobj,
     rgl (>= 0.106.8),
     testthat,
     vdiffr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,20 @@
 piecepackr 1.8.0
 ================
 
+New features
+------------
+
 * The R6 object returned by `pp_shape()` now has a new `pattern()` method that fills 
   the shape with a specified pattern.  Requires the suggested package `{gridpattern}` (#228).
+
+Bug fixes and minor improvements
+--------------------------------
+
+* If the suggested package `{readobj}` is installed then the default
+  ``piece3d()`` method will import Wavefront OBJ files with ``readobj::read.obj()``
+  instead of ``rgl::readOBJ()``.  In particular ``readobj::read.obj()`` can
+  successfully triangulate the "meeple" shape and the "roundrect" shape (#220).
+
 
 piecepackr 1.7.2
 ================

--- a/R/piece3d-rgl.R
+++ b/R/piece3d-rgl.R
@@ -88,6 +88,10 @@ rgl_piece_helper <- function(piece_side = "tile_back", suit = NA, rank = NA, cfg
                      lit = lit, shininess = shininess,
                      front = "filled", back = "filled",
                      texture = obj$png, textype = textype)
-    mesh <- suppressWarnings(rgl::readOBJ(obj$obj, material = material))
-    invisible(as.numeric(rgl::shade3d(mesh)))
+    mesh <- tryCatch(suppressWarnings(rgl::readOBJ(obj$obj)), error = function(e) {
+                         assert_suggested("readobj")
+                         readobj::read.obj(obj$obj, convert.rgl=TRUE)
+                     })
+    id <- rgl::shade3d(mesh, material = material)
+    invisible(as.numeric(id))
 }

--- a/R/piece3d-rgl.R
+++ b/R/piece3d-rgl.R
@@ -88,10 +88,10 @@ rgl_piece_helper <- function(piece_side = "tile_back", suit = NA, rank = NA, cfg
                      lit = lit, shininess = shininess,
                      front = "filled", back = "filled",
                      texture = obj$png, textype = textype)
-    mesh <- tryCatch(suppressWarnings(rgl::readOBJ(obj$obj)), error = function(e) {
-                         assert_suggested("readobj")
-                         readobj::read.obj(obj$obj, convert.rgl=TRUE)
-                     })
+    if (requireNamespace("readobj"))
+        mesh <- readobj::read.obj(obj$obj, convert.rgl = TRUE)
+    else
+        mesh <- rgl::readOBJ(obj$obj)
     id <- rgl::shade3d(mesh, material = material)
     invisible(as.numeric(id))
 }


### PR DESCRIPTION
* Patiently waiting for @jefferis to merge https://github.com/jefferis/readobj/pull/8
  and then release to CRAN before merging this PR
* This should fix 'piece3d()' bug when drawing
  'roundrect' and 'meeple' shapes (#226)
