### PR TITLE
refactor!(get_embedded_font()): No 'pdffonts' fallback

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: piecepackr
 Type: Package
 Title: Board Game Graphics
-Version: 1.14.0-1
+Version: 1.14.0-2
 Description: Functions to make board game graphics with the 'ggplot2', 'grid', 'rayrender', 'rayvertex', and 'rgl' packages.  Specializes in game diagrams, animations, and "Print & Play" layouts for the 'piecepack' <https://www.ludism.org/ppwiki> but can make graphics for other board game systems.  Includes configurations for several public domain game systems such as checkers, (double-18) dominoes, go, 'piecepack', playing cards, etc.
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
-piecepackr (development)
-========================
+piecepackr 1.14.0 (development)
+===============================
+
+Breaking changes
+----------------
+
+* Some features which were deprecated by v1.13.1 (2023-03-23) have been removed:
+
+  + `get_embedded_font()` no longer falls back on the use of the command-line utility `pdffonts`
+    if the suggested R package `{pdftools}` is not installed.
+    Please install the suggested R package `{pdftools}` to use `get_embedded_font()`.
+
+Bug fixes and minor improvements
+--------------------------------
 
 * Although angles can continue to be numeric vectors they can now also
   be `affiner::angle()` vectors:
@@ -62,7 +74,7 @@ Breaking changes
   you'll get message informing you that `{piecepackr}` was unable to embed certain metadata.
   These messages have class `"piecepackr_embed_metadata"` and can also be suppressed by setting
   `options(piecepackr.metadata.inform = FALSE)`.
-* Some features which were deprecated by v1.10.3 (2022-03-23) have been removed:
+* Some features which were deprecated by v1.10.3 (2022-03-22) have been removed:
 
   - The `use_pictureGrob` argument of `grid.piece()` / `pieceGrob()` which was deprecated in v1.8.1 (2021-08-11) has been removed.
     Use `type = "picture"` instead of `use_pictureGrob = TRUE`.
@@ -73,7 +85,7 @@ Breaking changes
     has been removed. The public method `get_op_grob()` returns the complete oblique projection grob.
   - `animate_pieces()`'s `annotate` argument must now always be set as a named argument
     (or rely on its default value).
-    Setting it positionally was deprecated in v1.10.3 (2022-03-23).
+    Setting it positionally was deprecated in v1.10.3 (2022-03-22).
 
 Deprecated features
 -------------------

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,8 @@ destination: "../../websites/R/piecepackr/"
 url: "https://trevorldavis.com/R/piecepackr"
 development:
     mode: auto
+template:
+  bootstrap: 5
 reference:
     - title: "Low-level graphics functions"
       desc: "Functions for directly creating board game graphics via various graphic systems"

--- a/man/piecepackr-package.Rd
+++ b/man/piecepackr-package.Rd
@@ -36,7 +36,7 @@ Useful links:
 }
 }
 \author{
-\strong{Maintainer}: Trevor L Davis \email{trevor.l.davis@gmail.com} (\href{https://orcid.org/0000-0001-6341-4639}{ORCID})
+\strong{Maintainer}: Trevor L. Davis \email{trevor.l.davis@gmail.com} (\href{https://orcid.org/0000-0001-6341-4639}{ORCID})
 
 Other contributors:
 \itemize{


### PR DESCRIPTION
* Fix all compilation notes from `pkgdown::build_site()`.
* Fix deprecation warning from `systemfonts::match_font()`.

BREAKING CHANGES:

* Some features which were deprecated by v1.13.1 (2023-03-23) have been removed:

  + `get_embedded_font()` no longer falls back on the use of the command-line utility `pdffonts` if the suggested R package `{pdftools}` is not installed. Please install the suggested R package `{pdftools}` to use `get_embedded_font()`.