### PR TITLE
feat: `crosshairGrob()` vectorized in most arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: piecepackr
 Type: Package
 Title: Board Game Graphics
-Version: 1.14.0-6
+Version: 1.14.0-7
 Description: Functions to make board game graphics with the 'ggplot2', 'grid', 'rayrender', 'rayvertex', and 'rgl' packages.  Specializes in game diagrams, animations, and "Print & Play" layouts for the 'piecepack' <https://www.ludism.org/ppwiki> but can make graphics for other board game systems.  Includes configurations for several public domain game systems such as checkers, (double-18) dominoes, go, 'piecepack', playing cards, etc.
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",

--- a/R/cropmarkGrob.R
+++ b/R/cropmarkGrob.R
@@ -84,7 +84,7 @@ grid.cropmark <- function(..., draw = TRUE) {
 
 #' @export
 makeContext.pp_cropmark <- function(x) {
-    x$gp$fill <- x$gp$fill %||% x$gp$col %||% "black"
+    x$gp$fill <- x$gp$fill %||% x$gp$col %||% get.gpar("col")$col
     x$gp$col <- NA
     x
 }

--- a/R/crosshairGrob.R
+++ b/R/crosshairGrob.R
@@ -1,9 +1,13 @@
 #' Draw crosshairs with grid
 #'
-#' `grid.crosshair()` draws \dQuote{crosshair(s)} to the active graphics device.
+#' `grid.crosshair()` draws crosshairs at the corners of a rectangular area.
 #' `crosshairGrob()` is its grid grob counterpart.
-#' Intended for use in adding crosshairs at the corners of
+#' They are intended for use in adding crosshairs at the corners of
 #' game pieces in print-and-play layouts.
+#'
+#' One can use the lower level `segmentsCrosshairGrob()` and `squaresCrosshairGrob()`
+#' (which can be drawn with [grid::grid.draw()])
+#' to add individual crosshairs to specified (x,y) locations.
 #'
 #' @inheritParams pieceGrob
 #' @param ch_width Width/height of `ch_grob`'s viewport.
@@ -68,11 +72,95 @@ crosshairGrob <- function(...,
     width <- scale * width
     height <- scale * height
 
-    gTree(x=x, y=y, angle=angle,
+    gTree(piece_side=piece_side, suit=suit, rank=rank, cfg=cfg,
+          x=x, y=y, angle=angle,
           width=width, height=height,
+          default.units=default.units, envir=envir,
+          scale=scale,
           ch_width=ch_width, ch_grob=ch_grob,
           name = name, gp = gp, vp = vp,
           cl = "pp_crosshair")
+}
+
+#' @export
+makeContent.pp_crosshair <- function(x) {
+    nn <- max(lengths(list(x$piece_side, x$suit, x$rank, x$x, x$y, x$angle,
+                           x$width, x$height,
+                           x$scale, x$bleed,
+                           x$ch_width)))
+    piece_side <- rep(x$piece_side, length.out=nn)
+    suit <- rep(x$suit, length.out=nn)
+    rank <- rep(x$rank, length.out=nn)
+    xc <- rep(x$x, length.out=nn)
+    yc <- rep(x$y, length.out=nn)
+    angle <- rep(x$angle, length.out=nn)
+
+    width <- rep(x$width, length.out=nn)
+    height <- rep(x$height, length.out=nn)
+
+    scale <- rep(x$scale, length.out=nn)
+
+    cfg <- get_cfg(x$cfg, x$envir)
+    cfg <- rep(c(cfg), length.out=nn)
+
+    ch_width <- rep(x$ch_width, length.out=nn)
+
+    gl <- gList()
+    for (i in seq(nn)) {
+        name <- paste0(".", i)
+        gl[[i]] <- crosshairGrobHelper(piece_side[i], suit[i], rank[i], cfg[[i]],
+                                       xc[i], yc[i], angle[i],
+                                       width[i], height[i], x$default.units,
+                                       scale[i], name,
+                                       ch_width[i], x$ch_grob)
+    }
+    setChildren(x, gl)
+}
+
+crosshairGrobHelper <- function(piece_side="tile_back", suit=NA, rank=NA, cfg=pp_cfg(),
+                               x=unit(0.5, "npc"), y=unit(0.5, "npc"),
+                               angle=0, width=NA, height=NA,
+                               default.units = "npc",
+                               scale=1, name="",
+                               ch_width=unit(0.25, "mm"),
+                               ch_grob=unit(0.125, "in")) {
+    if (is.na(width) || is.na(height)) {
+        cfg <- as_pp_cfg(cfg)
+        rank <- impute_rank(piece_side, rank, cfg)
+        suit <- impute_suit(piece_side, suit, cfg)
+        if (is.na(width)) width <- inch(cfg$get_width(piece_side, suit, rank))
+        if (is.na(height)) height <- inch(cfg$get_height(piece_side, suit, rank))
+    }
+
+    if (is.na(angle))
+        angle <- 0
+    else
+        angle <- angle %% 360
+
+    if (!is.unit(x)) x <- unit(x, default.units)
+    if (!is.unit(y)) y <- unit(y, default.units)
+    if (!is.unit(width)) width <- unit(width, default.units)
+    if (!is.unit(height)) height <- unit(height, default.units)
+    if (!is.unit(ch_width)) ch_width <- unit(ch_width, default.units)
+
+    width <- scale * width
+    height <- scale * height
+
+    vp_piece <- viewport(x=x, y=y, angle=angle, width=width, height=height)
+
+    vp_ll <- viewport(x=0, y=0, width=ch_width, height=ch_width)
+    vp_ul <- viewport(x=0, y=1, width=ch_width, height=ch_width)
+    vp_lr <- viewport(x=1, y=0, width=ch_width, height=ch_width)
+    vp_ur <- viewport(x=1, y=1, width=ch_width, height=ch_width)
+
+    ch_ll <- grobTree(ch_grob, name = "crosshair_ll", vp = vp_ll)
+    ch_ul <- grobTree(ch_grob, name = "crosshair_ul", vp = vp_ul)
+    ch_lr <- grobTree(ch_grob, name = "crosshair_lr", vp = vp_lr)
+    ch_ur <- grobTree(ch_grob, name = "crosshair_ur", vp = vp_ur)
+
+    name <- paste0("crosshair", name)
+
+    grobTree(ch_ll, ch_ul, ch_lr, ch_ur, vp = vp_piece, name = name)
 }
 
 #' @rdname grid.crosshair
@@ -90,49 +178,92 @@ grid.crosshair <- function(..., draw = TRUE) {
 
 #' @rdname grid.crosshair
 #' @export
-segmentsCrosshairGrob <- function(..., gp = gpar()) {
-    col <- gp$col %||% "black"
+segmentsCrosshairGrob <- function(...,
+                                  x = unit(0.5, "npc"),
+                                  y = unit(0.5, "npc"),
+                                  width = unit(1, "snpc"),
+                                  height = unit(1, "snpc"),
+                                  default.units = "npc",
+                                  name = NULL, gp = gpar(), vp = NULL) {
+    col <- gp$col %||% gp$fill %||% "black"
     lwd <- gp$lwd %||% 1
     lty <- gp$lty %||% "solid"
 
     gp <- gpar(col = col, lwd = lwd, lty = lty)
-    gList(segmentsGrob(x0 = 0.5, x1 = 0.5, y0 = 0, y1 = 1,
-                       gp = gp, default.units = "snpc"),
-          segmentsGrob(x0 = 0, x1 = 1, y0 = 0.5, y1 = 0.5,
-                       gp = gp, default.units = "snpc"))
+
+    nn <- max(lengths(list(x, y, width, height)))
+    x <- rep(x, length.out = nn)
+    y <- rep(y, length.out = nn)
+    width <- rep(width, length.out = nn)
+    height <- rep(height, length.out = nn)
+    if (!is.unit(x))
+        x <- unit(x, default.units)
+    if (!is.unit(y))
+        y <- unit(y, default.units)
+    if (!is.unit(width))
+        width <- unit(width, default.units)
+    if (!is.unit(height))
+        height <- unit(height, default.units)
+
+    gl <- gList()
+    for (i in seq(nn)) {
+        vpi <- viewport(x = x[i], y = y[i], width = width[i], height = height[i])
+        gl[[i]] <- grobTree(segmentsGrob(x0 = 0.5, x1 = 0.5, y0 = 0, y1 = 1,
+                                         default.units = "snpc"),
+                            segmentsGrob(x0 = 0, x1 = 1, y0 = 0.5, y1 = 0.5,
+                                         default.units = "snpc"),
+                            name = paste0("crosshair.", i), vp = vpi)
+    }
+    gTree(name = name, gp = gp, vp = vp, children = gl, cl = "pp_segments_crosshair")
 }
 
 #' @rdname grid.crosshair
 #' @export
-squaresCrosshairGrob <- function(..., gp = gpar()) {
-    fill <- gp$fill%||% c("black", "white")
+squaresCrosshairGrob <- function(...,
+                                 x = unit(0.5, "npc"),
+                                 y = unit(0.5, "npc"),
+                                 width = unit(1, "snpc"),
+                                 height = unit(1, "snpc"),
+                                 default.units = "npc",
+                                 name = NULL, gp = gpar(), vp = NULL) {
+    fill <- gp$fill %||% gp$col %||% c("black", "white")
     if (length(fill) == 1L)
-        fill <- c(fill, "white")
+        fill <- c(fill, opposite_col(fill))
 
     gp1 <- gpar(col = NA, fill = fill[1L])
     gp2 <- gpar(col = NA, fill = fill[2L])
-    gList(rectGrob(x = c(0.1, 0.3, 0.5, 0.5, 0.5, 0.5, 0.5, 0.7, 0.9),
-                   y = c(0.5, 0.5, 0.1, 0.3, 0.5, 0.7, 0.9, 0.5, 0.5), 
-                   width = 0.1, height = 0.1, gp = gp1, default.units = "snpc"),
-          rectGrob(x = c(0.2, 0.4, 0.5, 0.5, 0.5, 0.5, 0.6, 0.8),
-                   y = c(0.5, 0.5, 0.2, 0.4, 0.6, 0.8, 0.5, 0.5),
-                   width = 0.1, height = 0.1, gp = gp2, default.units = "snpc"))
+
+    nn <- max(lengths(list(x, y, width, height)))
+    x <- rep(x, length.out = nn)
+    y <- rep(y, length.out = nn)
+    width <- rep(width, length.out = nn)
+    height <- rep(height, length.out = nn)
+    if (!is.unit(x))
+        x <- unit(x, default.units)
+    if (!is.unit(y))
+        y <- unit(y, default.units)
+    if (!is.unit(width))
+        width <- unit(width, default.units)
+    if (!is.unit(height))
+        height <- unit(height, default.units)
+
+    gl <- gList()
+    for (i in seq(nn)) {
+        vpi <- viewport(x = x[i], y = y[i], width = width[i], height = height[i])
+        gl[[i]] <- grobTree(rectGrob(x = c(0.1, 0.3, 0.5, 0.5, 0.5, 0.5, 0.5, 0.7, 0.9),
+                                     y = c(0.5, 0.5, 0.1, 0.3, 0.5, 0.7, 0.9, 0.5, 0.5),
+                                     width = 0.1, height = 0.1, gp = gp1, default.units = "snpc"),
+                            rectGrob(x = c(0.2, 0.4, 0.5, 0.5, 0.5, 0.5, 0.6, 0.8),
+                                     y = c(0.5, 0.5, 0.2, 0.4, 0.6, 0.8, 0.5, 0.5),
+                                     width = 0.1, height = 0.1, gp = gp2, default.units = "snpc"),
+                            name = paste0("crosshair.", i), vp = vpi)
+    }
+    gTree(name = name, gp = gp, vp = vp, children = gl, cl = "pp_squares_crosshair")
 }
 
-#' @export
-makeContent.pp_crosshair <- function(x) {
-    vp_piece <- viewport(x=x$x, y=x$y, angle=x$angle, width=x$width, height=x$height)
-
-    vp_ll <- viewport(x=0, y=0, width=x$ch_width, height=x$ch_width)
-    vp_ul <- viewport(x=0, y=1, width=x$ch_width, height=x$ch_width)
-    vp_lr <- viewport(x=1, y=0, width=x$ch_width, height=x$ch_width)
-    vp_ur <- viewport(x=1, y=1, width=x$ch_width, height=x$ch_width)
-
-    ch_ll <- grobTree(x$ch_grob, name = "crosshair_ll", vp = vpStack(vp_piece, vp_ll))
-    ch_ul <- grobTree(x$ch_grob, name = "crosshair_ul", vp = vpStack(vp_piece, vp_ul))
-    ch_lr <- grobTree(x$ch_grob, name = "crosshair_lr", vp = vpStack(vp_piece, vp_lr))
-    ch_ur <- grobTree(x$ch_grob, name = "crosshair_ur", vp = vpStack(vp_piece, vp_ur))
-
-    gl <- gList(ch_ll, ch_ul, ch_lr, ch_ur)
-    setChildren(x, gl)
+# Opposite color in RGB space
+opposite_col <- function(col) {
+    stopifnot(length(col) == 1L)
+    x <- grDevices::col2rgb(col)
+    grDevices::rgb(255 - x[[1, 1]], 255 - x[[2, 1]], 255 - x[[3, 1]], maxColorValue=255)
 }

--- a/man/grid.crosshair.Rd
+++ b/man/grid.crosshair.Rd
@@ -30,9 +30,29 @@ crosshairGrob(
 
 grid.crosshair(..., draw = TRUE)
 
-segmentsCrosshairGrob(..., gp = gpar())
+segmentsCrosshairGrob(
+  ...,
+  x = unit(0.5, "npc"),
+  y = unit(0.5, "npc"),
+  width = unit(1, "snpc"),
+  height = unit(1, "snpc"),
+  default.units = "npc",
+  name = NULL,
+  gp = gpar(),
+  vp = NULL
+)
 
-squaresCrosshairGrob(..., gp = gpar())
+squaresCrosshairGrob(
+  ...,
+  x = unit(0.5, "npc"),
+  y = unit(0.5, "npc"),
+  width = unit(1, "snpc"),
+  height = unit(1, "snpc"),
+  default.units = "npc",
+  name = NULL,
+  gp = gpar(),
+  vp = NULL
+)
 }
 \arguments{
 \item{...}{\code{crosshairGrob()} ignores; \code{grid.crosshair()} passes to \code{crosshairGrob()}.}
@@ -85,10 +105,15 @@ black/white squares for visibility on both light and dark backgrounds.}
 A grid grob.
 }
 \description{
-\code{grid.crosshair()} draws \dQuote{crosshair(s)} to the active graphics device.
+\code{grid.crosshair()} draws \dQuote{crosshair(s)} at the corners of a rectangular area.
 \code{crosshairGrob()} is its grid grob counterpart.
-Intended for use in adding crosshairs at the corners of
+They are intended for use in adding crosshairs at the corners of
 game pieces in print-and-play layouts.
+}
+\details{
+One can use the lower level \code{segmentsCrosshairGrob()} and \code{squaresCrosshairGrob()}
+(which can be drawn with \code{\link[grid:grid.draw]{grid::grid.draw()}})
+to add individual crosshairs to specified (x,y) locations.
 }
 \examples{
 if (requireNamespace("grid", quietly = TRUE) &&


### PR DESCRIPTION
* `crosshairGrob()` / `grid.crosshair()` is now vectorized in most of its arguments.
* `segmentsCrosshairGrob()` and `squaresCrosshairGrob()` now accept (vectorized) `x`, `y`, `width`, `height` arguments and can now be more easily used (with `grid.draw()`) to draw individual crosshairs.