### PR TITLE
feat!: Vectorized `save_piece_obj()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: piecepackr
 Type: Package
 Title: Board Game Graphics
-Version: 1.14.0-8
+Version: 1.14.0-9
 Description: Functions to make board game graphics with the 'ggplot2', 'grid', 'rayrender', 'rayvertex', and 'rgl' packages.  Specializes in game diagrams, animations, and "Print & Play" layouts for the 'piecepack' <https://www.ludism.org/ppwiki> but can make graphics for other board game systems.  Includes configurations for several public domain game systems such as checkers, (double-18) dominoes, go, 'piecepack', playing cards, etc.
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,15 @@ Breaking changes
     if the suggested R package `{pdftools}` is not installed.
     Please install the suggested R package `{pdftools}` to use `get_embedded_font()`.
 
+* Newly vectorized `save_piece_obj()` now returns a data frame (instead of a named list)
+  with (the same) "obj", "mtl", and "png" names.
+  Each row contains the file paths for a Wavefront ".obj" file and its associated ".mtl" and ".png" files.
+  Each piece may now be represented by one or several ".obj" files.
+  Previously `save_piece_obj()` was not vectorized and returned a list with names "obj", "mtl", and "png"
+  with the file paths for a single Wavefront ".obj" file and its associated ".mtl" and ".png" files and it used
+  to throw an error instead of saving multiple ".obj" files for certain "composite" pieces
+  (like the "joystick" pawn or "reversi" disc).
+
 New features
 ------------
 
@@ -56,6 +65,12 @@ Bug fixes and minor improvements
 
 * `cropmarkGrob()` / `grid.cropmark()` no longer ignores `name`, `gp`, and `vp` arguments (#340).
 * `cropmarkGrob()` / `grid.cropmark()` is now vectorized in most of its arguments.
+* `save_piece_obj()` improvements (#347):
+
+  + Most arguments are now vectorized and `save_piece_obj()` now returns a data frame with "obj", "mtl", and "png" names.
+  + Each row contains the file paths for a Wavefront ".obj" file and its associated ".mtl" and ".png" files.
+  + Each piece may now be represented by one or several ".obj" files.  In particular instead of throwing an error
+    we now generate (multiple) ".obj" files to represent "composite" pieces like the "joystick" pawns and "reversi" discs.
 
 piecepackr 1.13.11
 ==================

--- a/R/game_systems.R
+++ b/R/game_systems.R
@@ -905,10 +905,7 @@ reversi_piece <- function(cell_width = 1, color_list = color_list_fn()) {
          depth.bit = 0.25 * cell_width,
          grob_fn.bit = reversi_piece$grob_fn,
          obj_fn.bit = reversi_piece$obj_fn,
-         op_grob_fn.bit = reversi_piece$op_grob_fn,
-         rayrender_fn.bit = reversi_piece$rayrender_fn,
-         rayvertex_fn.bit = reversi_piece$rayvertex_fn,
-         rgl_fn.bit = reversi_piece$rgl_fn)
+         op_grob_fn.bit = reversi_piece$op_grob_fn)
 }
 
 peg_doll_pawn <- function(shapes) {
@@ -948,9 +945,6 @@ joystick_pawn <- function(shapes) {
     list(grob_fn.pawn = joystick$grob_fn,
          obj_fn.pawn = joystick$obj_fn,
          op_grob_fn.pawn = joystick$op_grob_fn,
-         rayrender_fn.pawn = joystick$rayrender_fn,
-         rayvertex_fn.pawn = joystick$rayvertex_fn,
-         rgl_fn.pawn = joystick$rgl_fn,
          width.pawn=5/8, height.pawn=1.0, depth.pawn=5/8)
 }
 

--- a/R/piece-rayrender.R
+++ b/R/piece-rayrender.R
@@ -65,13 +65,14 @@ rr_piece_helper <- function(piece_side = "tile_back", suit = NA, rank = NA, cfg 
                            angle = 0, axis_x = 0, axis_y = 0,
                            width = NA, height = NA, depth = NA, scale = 1, res = 72) {
     if (scale == 0) return(NULL)
-    obj <- save_piece_obj(piece_side, suit, rank, cfg,
-                        x = x, y = y, z = z,
-                        angle = angle, axis_x = axis_x, axis_y = axis_y,
-                        width = width, height = height, depth = depth,
-                        scale = scale, res = res)
+    l_obj <- save_piece_obj(piece_side, suit, rank, cfg,
+                            x = x, y = y, z = z,
+                            angle = angle, axis_x = axis_x, axis_y = axis_y,
+                            width = width, height = height, depth = depth,
+                            scale = scale, res = res)
     if (packageVersion("rayrender") < "0.28.0")
-        rayrender::obj_model(filename = obj$obj, texture = TRUE)
+        l <- lapply(l_obj$obj, rayrender::obj_model, texture = TRUE)
     else
-        rayrender::obj_model(filename = obj$obj, load_material = TRUE, load_textures = TRUE)
+        l <- lapply(l_obj$obj, rayrender::obj_model, load_material = TRUE, load_textures = TRUE)
+    Reduce(rayrender::add_object, l)
 }

--- a/R/piece_mesh-rayvertex.R
+++ b/R/piece_mesh-rayvertex.R
@@ -59,13 +59,7 @@ piece_mesh <- function(piece_side = "tile_back", suit = NA, rank = NA, cfg = pp_
                      scale = scale[i], res = res)
     })
     l <- Filter(Negate(is.null), l)
-    if (length(l) == 1L) {
-        l[[1L]]
-    } else if (length(l) > 1L) {
-        rayvertex::scene_from_list(l)
-    } else {
-        NULL
-    }
+    rv_from_list(l)
 }
 
 rv_piece_helper <- function(piece_side = "tile_back", suit = NA, rank = NA, cfg = pp_cfg(), # nolint
@@ -73,10 +67,21 @@ rv_piece_helper <- function(piece_side = "tile_back", suit = NA, rank = NA, cfg 
                            angle = 0, axis_x = 0, axis_y = 0,
                            width = NA, height = NA, depth = NA, scale = 1, res = 72) {
     if (scale == 0) return(NULL)
-    obj <- save_piece_obj(piece_side, suit, rank, cfg,
+    l_obj <- save_piece_obj(piece_side, suit, rank, cfg,
                         x = x, y = y, z = z,
                         angle = angle, axis_x = axis_x, axis_y = axis_y,
                         width = width, height = height, depth = depth,
                         scale = scale, res = res)
-    rayvertex::obj_mesh(filename = obj$obj)
+    l <- lapply(l_obj$obj, rayvertex::obj_mesh)
+    rv_from_list(l)
+}
+
+rv_from_list <- function(l) {
+    if (length(l) == 1L) {
+        l[[1L]]
+    } else if (length(l) > 1L) {
+        rayvertex::scene_from_list(l)
+    } else {
+        NULL
+    }
 }

--- a/man/obj_fns.Rd
+++ b/man/obj_fns.Rd
@@ -76,7 +76,7 @@ can be retrieved by \code{base::dynGet()}.}
 
 \item{depth}{Depth (thickness) of piece.  Has no effect if \code{op_scale} is \code{0}.}
 
-\item{filename}{Name of Wavefront OBJ object.}
+\item{filename}{Name of Wavefront OBJ object.  By default \code{tempfile(fileext = ".obj")}.}
 
 \item{subdivide}{Increasing this value makes for a smoother ellipsoid (and larger OBJ file and slower render).
 See \code{\link[rgl]{ellipse3d}}.}

--- a/man/save_piece_obj.Rd
+++ b/man/save_piece_obj.Rd
@@ -19,7 +19,8 @@ save_piece_obj(
   width = NA,
   height = NA,
   depth = NA,
-  filename = tempfile(fileext = ".obj"),
+  envir = getOption("piecepackr.envir"),
+  filename = tempfile(fileext = "\%03d.obj"),
   scale = 1,
   res = 72
 )
@@ -57,14 +58,16 @@ can be retrieved by \code{base::dynGet()}.}
 
 \item{depth}{Depth (thickness) of piece.  Has no effect if \code{op_scale} is \code{0}.}
 
-\item{filename}{Name of Wavefront OBJ object.}
+\item{envir}{Environment (or named list) containing configuration list(s).}
+
+\item{filename}{Name of Wavefront OBJ object.  By default \code{tempfile(fileext = ".obj")}.}
 
 \item{scale}{Multiplicative scaling factor to apply to width, height, and depth.}
 
 \item{res}{Resolution of the faces.}
 }
 \value{
-A list with named elements "obj", "mtl", "png" with the created filenames.
+A data frame with named elements "obj", "mtl", "png" with the created filenames.
 }
 \description{
 \code{save_piece_obj} saves Wavefront OBJ files (including associated MTL and texture image) of board game pieces.


### PR DESCRIPTION
* `save_piece_obj()` improvements (#347):

  + Most arguments are now vectorized and `save_piece_obj()` now returns a data frame with "obj", "mtl", and "png" names.
  + Each row contains the file paths for a Wavefront ".obj" file and its associated ".mtl" and ".png" files.
  + Each piece may now be represented by one or several ".obj" files.  In particular instead of throwing an error we now generate (multiple) ".obj" files to represent "composite" pieces like the "joystick" pawns and "reversi" discs.

BREAKING CHANGES:

* Newly vectorized `save_piece_obj()` now returns a data frame (instead of a named list) with (the same) "obj", "mtl", and "png" names. Each row contains the file paths for a Wavefront ".obj" file and its associated ".mtl" and ".png" files. Each piece may now be represented by one or several ".obj" files. Previously `save_piece_obj()` was not vectorized and returned a list with names "obj", "mtl", and "png" with the file paths for a single Wavefront ".obj" file and its associated ".mtl" and ".png" files and it used to throw an error instead of saving multiple ".obj" files for certain "composite" pieces (like the "joystick" pawn or "reversi" disc).

closes #347