### PR TITLE
Deprecate "preview_layout" and remove previously deprecated arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: piecepackr
 Type: Package
 Title: Board Game Graphics
-Version: 1.16.0-3
+Version: 1.16.0-4
 Description: Functions to make board game graphics with the 'ggplot2', 'grid', 'rayrender', 'rayvertex', and 'rgl' packages.  Specializes in game diagrams, animations, and "Print & Play" layouts for the 'piecepack' <https://www.ludism.org/ppwiki> but can make graphics for other board game systems.  Includes configurations for several public domain game systems such as checkers, (double-18) dominoes, go, 'piecepack', playing cards, etc.
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 piecepackr 1.16.0 (development)
 ===============================
 
+Deprecated features
+-------------------
+
+* The `"preview_layout"` component of `grid.piece()` / `pieceGrob()` is now deprecated.
+  Use `ppdf::piecepack_preview() |> pmap_piece(cfg = cfg, default.units = "in")` instead (#164).
+
 New features
 ------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 piecepackr 1.16.0 (development)
 ===============================
 
+Breaking changes
+----------------
+
+* The `new_device` argument of `animate_piece()` and `render_piece()` has been removed.
+  Use the `open_device` argument instead.
+* The `style` argument of `game_systems()` and the (undocumented) use of a `"3d"` suffix in the `font` argument have been removed.
+  Use the `font`, `border`, `background_color`, and/or `edge_color` arguments instead.
+
 Deprecated features
 -------------------
 

--- a/R/animate_piece.R
+++ b/R/animate_piece.R
@@ -25,8 +25,6 @@
 #' @param fps Double, frames per second.
 #' @param xbreaks,ybreaks Subset (of integers) to provide axis labels for if `annotate` is `TRUE`.
 #'                        If `NULL` infer a reasonable choice.
-#' @param new_device If `file` is `NULL` should we open up a new graphics device?
-#'                   This argument is deprecated.  Use the `open_device` argument instead.
 #' @return Nothing, as a side effect creates an animation.
 #' @examples
 #'   # Basic tic-tac-toe animation
@@ -81,20 +79,13 @@ animate_piece <- function(
 	ppi = NULL,
 	annotate = TRUE,
 	annotation_scale = NULL,
-	open_device = new_device,
+	open_device = TRUE,
 	n_transitions = 0L,
 	n_pauses = 1L,
 	fps = n_transitions + n_pauses,
 	xbreaks = NULL,
-	ybreaks = NULL,
-	new_device = TRUE
+	ybreaks = NULL
 ) {
-	if (!missing(new_device)) {
-		warn(
-			"The argument `new_device` is deprecated.  Use `open_device` instead.",
-			class = "deprecatedWarning"
-		)
-	}
 	if (n_transitions > 0L) {
 		assert_suggested("tweenr")
 	}

--- a/R/game_systems.R
+++ b/R/game_systems.R
@@ -122,7 +122,6 @@
 #'               drawing with `{grid}` graphics and `FALSE` when drawing with 3D graphic systems.
 #' @param background_color Background color to use for certain pieces like boards and piecepack tiles.
 #' @param edge_color Edge color to use for certain pieces like boards and piecepack tiles.
-#' @param style Deprecated argument.
 #' @examples
 #' cfgs <- game_systems(pawn = "joystick")
 #' names(cfgs)
@@ -179,40 +178,16 @@
 #' @seealso [pp_cfg()] for information about the [pp_cfg()] objects returned by `game_systems()`.
 #' @export
 game_systems <- function(
-	font = style,
+	font = NULL,
 	round = FALSE,
 	pawn = "token",
 	...,
 	shading = FALSE,
 	border = TRUE,
 	background_color = ifelse(border, "white", "burlywood"),
-	edge_color = ifelse(border, "white", "black"),
-	style = NULL
+	edge_color = ifelse(border, "white", "black")
 ) {
 	check_dots_empty()
-	if (!missing(style)) {
-		warn(
-			"The argument `style` is deprecated.  Use the `font`, `border`, `background_color`, and/or `edge_color` arguments instead.",
-			class = "deprecatedWarning"
-		)
-	}
-	if (is.character(font) && grepl("3d$", font)) {
-		warn(
-			"Including a '3d' at the end of the `font` or `style` argument is deprecated.  Use the `border`, `background_color`, and/or `edge_color` arguments instead.",
-			class = "deprecatedWarning"
-		)
-
-		if (missing(border)) {
-			border <- FALSE
-		}
-		if (missing(background_color)) {
-			background_color <- ifelse(border, "white", "burlywood")
-		}
-		if (missing(edge_color)) {
-			edge_color <- ifelse(border, "white", "black")
-		}
-		font <- gsub("3d$", "", font)
-	}
 	font <- game_systems_font(font)
 
 	rect_shape <- ifelse(round, "roundrect", "rect")

--- a/R/pieceGrob-grid.R
+++ b/R/pieceGrob-grid.R
@@ -247,6 +247,15 @@ pieceGrob <- function(
 	bleed = FALSE
 ) {
 	stopifnot(!(bleed && op_scale > 0))
+	if (any(piece_side == "preview_layout")) {
+		warn(
+			paste0(
+				'The "preview_layout" component is deprecated. ',
+				'Use `ppdf::piecepack_preview() |> pmap_piece(cfg = cfg, default.units = "in")` instead.'
+			),
+			class = "deprecatedWarning"
+		)
+	}
 	if (is_angle(angle)) {
 		angle <- as.double(angle, "degrees")
 	}

--- a/R/render_piece.R
+++ b/R/render_piece.R
@@ -35,7 +35,6 @@
 #'              using [grDevices::dev.capture()] or `as.raster(magick::image_read())`.
 #' @param xbreaks,ybreaks Subset (of integers) to provide axis labels for if `annotate` is `TRUE`.
 #'                        If `NULL` infer a reasonable choice.
-#' @param new_device If `FALSE` draw in the active graphics device instead of opening a new graphics device.  This argument is deprecated.  Use the `open_device` argument instead.
 #' @return An invisible list of the dimensions of the image and
 #'         possibly an image object specified by `image`.
 #'         As a side effect may save a file and/or open/close a graphics device.
@@ -87,19 +86,12 @@ render_piece <- function(
 	annotation_scale = NULL,
 	dev = NULL,
 	dev.args = list(res = ppi, bg = bg, units = "in"),
-	open_device = new_device,
+	open_device = TRUE,
 	close_device = open_device && (!is.null(file) || !is.null(dev)),
 	image = c("NULL", "raster", "nativeRaster"),
 	xbreaks = NULL,
-	ybreaks = NULL,
-	new_device = TRUE
+	ybreaks = NULL
 ) {
-	if (!missing(new_device)) {
-		warn(
-			"The argument `new_device` is deprecated.  Use `open_device` instead.",
-			class = "deprecatedWarning"
-		)
-	}
 	stopifnot(is.null(dev) || is.function(dev))
 	image <- match.arg(image)
 	if (image == "NULL") {

--- a/man/animate_piece.Rd
+++ b/man/animate_piece.Rd
@@ -16,13 +16,12 @@ animate_piece(
   ppi = NULL,
   annotate = TRUE,
   annotation_scale = NULL,
-  open_device = new_device,
+  open_device = TRUE,
   n_transitions = 0L,
   n_pauses = 1L,
   fps = n_transitions + n_pauses,
   xbreaks = NULL,
-  ybreaks = NULL,
-  new_device = TRUE
+  ybreaks = NULL
 )
 }
 \arguments{
@@ -65,9 +64,6 @@ how many transition frames to add between moves.}
 
 \item{xbreaks, ybreaks}{Subset (of integers) to provide axis labels for if \code{annotate} is \code{TRUE}.
 If \code{NULL} infer a reasonable choice.}
-
-\item{new_device}{If \code{file} is \code{NULL} should we open up a new graphics device?
-This argument is deprecated.  Use the \code{open_device} argument instead.}
 }
 \value{
 Nothing, as a side effect creates an animation.

--- a/man/game_systems.Rd
+++ b/man/game_systems.Rd
@@ -7,15 +7,14 @@
 \title{Standard game systems}
 \usage{
 game_systems(
-  font = style,
+  font = NULL,
   round = FALSE,
   pawn = "token",
   ...,
   shading = FALSE,
   border = TRUE,
   background_color = ifelse(border, "white", "burlywood"),
-  edge_color = ifelse(border, "white", "black"),
-  style = NULL
+  edge_color = ifelse(border, "white", "black")
 )
 
 to_hexpack(cfg = getOption("piecepackr.cfg", pp_cfg()))
@@ -45,8 +44,6 @@ drawing with \code{{grid}} graphics and \code{FALSE} when drawing with 3D graphi
 \item{background_color}{Background color to use for certain pieces like boards and piecepack tiles.}
 
 \item{edge_color}{Edge color to use for certain pieces like boards and piecepack tiles.}
-
-\item{style}{Deprecated argument.}
 
 \item{cfg}{List of configuration options}
 }

--- a/man/render_piece.Rd
+++ b/man/render_piece.Rd
@@ -21,12 +21,11 @@ render_piece(
   annotation_scale = NULL,
   dev = NULL,
   dev.args = list(res = ppi, bg = bg, units = "in"),
-  open_device = new_device,
+  open_device = TRUE,
   close_device = open_device && (!is.null(file) || !is.null(dev)),
   image = c("NULL", "raster", "nativeRaster"),
   xbreaks = NULL,
-  ybreaks = NULL,
-  new_device = TRUE
+  ybreaks = NULL
 )
 }
 \arguments{
@@ -81,8 +80,6 @@ If \code{"raster"} or \verb{"nativeRaster" try to return a raster object of the 
 
 \item{xbreaks, ybreaks}{Subset (of integers) to provide axis labels for if \code{annotate} is \code{TRUE}.
 If \code{NULL} infer a reasonable choice.}
-
-\item{new_device}{If \code{FALSE} draw in the active graphics device instead of opening a new graphics device.  This argument is deprecated.  Use the \code{open_device} argument instead.}
 }
 \value{
 An invisible list of the dimensions of the image and

--- a/tests/testthat/_snaps/game_systems.md
+++ b/tests/testthat/_snaps/game_systems.md
@@ -1,10 +1,10 @@
-# deprecated `style` argument warnings
+# removed `style` argument errors
 
     Code
-      invisible(game_systems(style = "dejavu3d"))
+      game_systems(style = "dejavu3d")
     Condition
-      Warning:
-      The argument `style` is deprecated.  Use the `font`, `border`, `background_color`, and/or `edge_color` arguments instead.
-      Warning:
-      Including a '3d' at the end of the `font` or `style` argument is deprecated.  Use the `border`, `background_color`, and/or `edge_color` arguments instead.
+      Error in `game_systems()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * style = "dejavu3d"
 

--- a/tests/testthat/_snaps/pieceGrob.md
+++ b/tests/testthat/_snaps/pieceGrob.md
@@ -1,0 +1,8 @@
+# deprecated 'preview_layout' component warning
+
+    Code
+      invisible(pieceGrob("preview_layout", cfg = cfg_default, default.units = "npc"))
+    Condition
+      Warning:
+      The "preview_layout" component is deprecated. Use `ppdf::piecepack_preview() |> pmap_piece(cfg = cfg, default.units = "in")` instead.
+

--- a/tests/testthat/test-game_systems.R
+++ b/tests/testthat/test-game_systems.R
@@ -3,10 +3,8 @@ test_that("no regressions in `game_systems()`", {
 })
 
 
-test_that("deprecated `style` argument warnings", {
-	skip_if_not_installed("systemfonts") # prevent buggy cairo interaction with "dejavu" font
-	skip_if_not(has_font("Dejavu Sans"))
-	expect_snapshot(invisible(game_systems(style = "dejavu3d")))
+test_that("removed `style` argument errors", {
+	expect_snapshot(error = TRUE, game_systems(style = "dejavu3d"))
 })
 
 test_that("no regressions in `game_systems()` figures", {

--- a/tests/testthat/test-pieceGrob.R
+++ b/tests/testthat/test-pieceGrob.R
@@ -278,12 +278,15 @@ test_that("no regressions in figures", {
 		dc("matchstick_back", cfg = cfg, suit = 3, rank = 6)
 	})
 
-	expect_doppelganger("preview", function() dc("preview_layout"))
+	expect_doppelganger("preview", function() suppressWarnings(dc("preview_layout")))
 	expect_doppelganger("preview-5s", function() {
-		dc("preview_layout", cfg = list(suit_text = "A,B,C,D,E,", die_arrangement = "counter_up"))
+		suppressWarnings(dc(
+			"preview_layout",
+			cfg = list(suit_text = "A,B,C,D,E,", die_arrangement = "counter_up")
+		))
 	})
 	expect_doppelganger("preview-6s", function() {
-		dc("preview_layout", cfg = list(suit_text = "I,II,III,IV,V,VI,"))
+		suppressWarnings(dc("preview_layout", cfg = list(suit_text = "I,II,III,IV,V,VI,")))
 	})
 
 	# dice
@@ -407,6 +410,14 @@ test_that("no regressions in figures", {
 		},
 		classes = "piecepackr_affine_transformation"
 	)
+})
+
+test_that("deprecated 'preview_layout' component warning", {
+	expect_snapshot(invisible(pieceGrob(
+		"preview_layout",
+		cfg = cfg_default,
+		default.units = "npc"
+	)))
 })
 
 test_that("oblique projection works", {


### PR DESCRIPTION
- **chore(pieceGrob): Deprecate "preview_layout" component (#164)**
  * The `"preview_layout"` component of `grid.piece()` / `pieceGrob()` is now deprecated.
    Use `ppdf::piecepack_preview() |> pmap_piece(cfg = cfg, default.units = "in")` instead (#164).
  
  closes #164
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **refactor!: Remove arguments deprecated in v1.15.1**
  BREAKING CHANGES:
  
  * The `new_device` argument of `animate_piece()` and `render_piece()` has been removed. Use the `open_device` argument instead.
  * The `style` argument of `game_systems()` and the (undocumented) use of a `"3d"` suffix in the `font` argument have been removed. Use the `font`, `border`, `background_color`, and/or `edge_color` arguments instead.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  