### PR TITLE
chore(save_print_and_play): Deprecate `size = "4x6"` (#300)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: piecepackr
 Type: Package
 Title: Board Game Graphics
-Version: 1.16.0-6
+Version: 1.16.0-7
 Description: Functions to make board game graphics with the 'ggplot2', 'grid', 'rayrender', 'rayvertex', and 'rgl' packages.  Specializes in game diagrams, animations, and "Print & Play" layouts for the 'piecepack' <https://www.ludism.org/ppwiki> but can make graphics for other board game systems.  Includes configurations for several public domain game systems such as checkers, (double-18) dominoes, go, 'piecepack', playing cards, etc.
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,10 @@ Breaking changes
 Deprecated features
 -------------------
 
-* The `"preview_layout"` component of `grid.piece()` / `pieceGrob()` is now deprecated.
-  Use `ppdf::piecepack_preview() |> pmap_piece(cfg = cfg, default.units = "in")` instead (#164).
+* The `"preview_layout"` component of `grid.piece()` / `pieceGrob()` is now deprecated (#164).
+  Use `ppdf::piecepack_preview() |> pmap_piece(cfg = cfg, default.units = "in")` instead.
+* `save_print_and_play(size = "4x6")` is now deprecated (#300).
+  Due to scaling and trimming issues with photo printing services this experimental format never worked that well in practice.
 
 New features
 ------------

--- a/R/save_print_and_play.R
+++ b/R/save_print_and_play.R
@@ -9,31 +9,26 @@ A4_HEIGHT <- 11.69
 #'
 #' @param cfg Piecepack configuration list or `pp_cfg` object
 #' @param output_filename Filename for print-and-play file
-#' @param size PnP output size (currently supports either "letter", "A4", "A5", or "4x6").
+#' @param size PnP output size (currently supports either "letter", "A4", or "A5").
 #'             This is the targeted \dQuote{trim} size of the print-and-play file
 #'             (`size_bleed` can be used to make the print-and-play file larger than this).
-#'             Size "4x6" currently only supports `pieces = "piecepack"`
-#'             and doesn't support `bleed = TRUE`.
 #'             "A5" is in \dQuote{portrait} mode whereas the other sizes are in \dQuote{landscape} mode.
 #' @param pieces Character vector of desired PnP pieces.
 #'        Supports "piecepack", "matchsticks", "pyramids", "subpack", or "all".
 #'        If `NULL` and combination of `size` / `bleed` values supports "matchsticks" and "pyramids"
 #'        then defaults to `c("piecepack", "pyramids", "matchsticks")` else just "piecepack".
 #' @param arrangement Either "single-sided" or "double-sided".
-#'                    Ignored if `size = "4x6"`.
 #' @param quietly Whether to hide messages about missing metadata
 #'                in the provided configuration.
 #' @param ... Currently ignored.
 #' @param bleed If `TRUE` produce a variant print-and-play file with "bleed" zones
 #'              and "crop marks" around game pieces.
-#'              Currently only supports `pieces = "piecepack"` and doesn't
-#'              support `size = "4x6"`.
+#'              Currently only supports `pieces = "piecepack"`.
 #' @param size_bleed A list with names "top", "right", "bottom", "left"
 #'                   containing numeric values indicating the inches "bleed" to add to
 #'                   the `size` of the print-and-play layout.
-#'                   The default `NULL` means no such bleed added to "letter", "A4", "A5"
-#'                   layouts and a small bleed added to "4x6" layouts
-#'                   (1/16" to top/bottom and 3/32" to left/right).
+#'                   The default `NULL` means no such bleed added to "letter", "A4", and "A5"
+#'                   layouts.
 #'                   NB. multiply millimeters by `0.0393700787` to convert to inches.
 #'                   We currently don't support an asymmetric left/right bleed combined with
 #'                   `arrangement = "double-sided"`.
@@ -78,6 +73,12 @@ save_print_and_play <- function(
 
 	stopifnot(is.null(dev) || is.function(dev))
 	size <- match.arg(size)
+	if (size == "4x6") {
+		warn(
+			'`size = "4x6"` is deprecated.',
+			class = "deprecatedWarning"
+		)
+	}
 	arrangement <- match.arg(arrangement)
 	if (is.null(pieces)) {
 		if (size == "4x6" || bleed) {

--- a/man/save_print_and_play.Rd
+++ b/man/save_print_and_play.Rd
@@ -24,11 +24,9 @@ save_print_and_play(
 
 \item{output_filename}{Filename for print-and-play file}
 
-\item{size}{PnP output size (currently supports either "letter", "A4", "A5", or "4x6").
+\item{size}{PnP output size (currently supports either "letter", "A4", or "A5").
 This is the targeted \dQuote{trim} size of the print-and-play file
 (\code{size_bleed} can be used to make the print-and-play file larger than this).
-Size "4x6" currently only supports \code{pieces = "piecepack"}
-and doesn't support \code{bleed = TRUE}.
 "A5" is in \dQuote{portrait} mode whereas the other sizes are in \dQuote{landscape} mode.}
 
 \item{pieces}{Character vector of desired PnP pieces.
@@ -36,8 +34,7 @@ Supports "piecepack", "matchsticks", "pyramids", "subpack", or "all".
 If \code{NULL} and combination of \code{size} / \code{bleed} values supports "matchsticks" and "pyramids"
 then defaults to \code{c("piecepack", "pyramids", "matchsticks")} else just "piecepack".}
 
-\item{arrangement}{Either "single-sided" or "double-sided".
-Ignored if \code{size = "4x6"}.}
+\item{arrangement}{Either "single-sided" or "double-sided".}
 
 \item{dev}{Graphics device function to use if \code{open_device} is \code{FALSE}.
 If \code{NULL} infer a reasonable choice from \code{file}.}
@@ -52,15 +49,13 @@ in the provided configuration.}
 
 \item{bleed}{If \code{TRUE} produce a variant print-and-play file with "bleed" zones
 and "crop marks" around game pieces.
-Currently only supports \code{pieces = "piecepack"} and doesn't
-support \code{size = "4x6"}.}
+Currently only supports \code{pieces = "piecepack"}.}
 
 \item{size_bleed}{A list with names "top", "right", "bottom", "left"
 containing numeric values indicating the inches "bleed" to add to
 the \code{size} of the print-and-play layout.
-The default \code{NULL} means no such bleed added to "letter", "A4", "A5"
-layouts and a small bleed added to "4x6" layouts
-(1/16" to top/bottom and 3/32" to left/right).
+The default \code{NULL} means no such bleed added to "letter", "A4", and "A5"
+layouts.
 NB. multiply millimeters by \code{0.0393700787} to convert to inches.
 We currently don't support an asymmetric left/right bleed combined with
 \code{arrangement = "double-sided"}.}

--- a/tests/testthat/_snaps/pieceGrob.md
+++ b/tests/testthat/_snaps/pieceGrob.md
@@ -1,3 +1,11 @@
+# `save_print_and_play(size = "4x6")` is deprecated
+
+    Code
+      save_print_and_play(pp_cfg(), f, size = "4x6", pieces = "piecepack", quietly = TRUE)
+    Condition
+      Warning:
+      `size = "4x6"` is deprecated.
+
 # deprecated 'preview_layout' component warning
 
     Code

--- a/tests/testthat/test-pieceGrob.R
+++ b/tests/testthat/test-pieceGrob.R
@@ -60,12 +60,15 @@ test_that("`save_print_and_play()` works as expected", {
 	)
 	save_print_and_play(cfg_default, pdf_deck_filename_a5, "A5", quietly = TRUE)
 
-	save_print_and_play(
-		cfg_default,
-		pdf_deck_filename_4x6,
-		"4x6",
-		pieces = "piecepack",
-		quietly = TRUE
+	suppressWarnings(
+		save_print_and_play(
+			cfg_default,
+			pdf_deck_filename_4x6,
+			"4x6",
+			pieces = "piecepack",
+			quietly = TRUE
+		),
+		classes = "deprecatedWarning"
 	)
 
 	save_print_and_play(cfg_default, pdf_deck_filename_bleed, bleed = TRUE, quietly = TRUE)
@@ -79,6 +82,15 @@ test_that("`save_print_and_play()` works as expected", {
 	expect_equal(xmpdf::n_pages(pdf_deck_filename_a5), 14, ignore_attr = "names")
 	expect_equal(xmpdf::n_pages(pdf_deck_filename_4x6), 13, ignore_attr = "names")
 	expect_equal(xmpdf::n_pages(pdf_deck_filename_bleed), 7, ignore_attr = "names")
+})
+
+test_that('`save_print_and_play(size = "4x6")` is deprecated', {
+	skip_if_not(capabilities("cairo"))
+	f <- tempfile(fileext = ".pdf")
+	on.exit(unlink(f))
+	expect_snapshot(
+		save_print_and_play(pp_cfg(), f, size = "4x6", pieces = "piecepack", quietly = TRUE)
+	)
 })
 
 test_that("`save_piece_images()` works as expected", {


### PR DESCRIPTION
closes #300

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
