### PR TITLE
Code review tweaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: piecepackr
 Type: Package
 Title: Board Game Graphics
-Version: 1.16.1
+Version: 1.16.2-1
 Description: Functions to make board game graphics with the 'ggplot2', 'grid', 'rayrender', 'rayvertex', and 'rgl' packages.  Specializes in game diagrams, animations, and "Print & Play" layouts for the 'piecepack' <https://www.ludism.org/ppwiki> but can make graphics for other board game systems.  Includes configurations for several public domain game systems such as checkers, (double-18) dominoes, go, 'piecepack', playing cards, etc.
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+piecepackr 1.16.2
+=================
+
+Bug fixes and minor improvements
+--------------------------------
+
+* `basicPieceGrob()` now correctly uses `dm_fontface` (instead of `ps_fontface`) when drawing the directional mark grob.
+
 piecepackr 1.16.1
 =================
 

--- a/R/animate_piece.R
+++ b/R/animate_piece.R
@@ -201,7 +201,11 @@ animation_fn <- function(file, open_device = TRUE) {
 			)
 		}
 	} else if (grepl(".bmp$|.jpg$|.jpeg$|.png$|.tiff$", file)) {
-		stopifnot(has_c_integer_format(file))
+		stopifnot(
+			'`file` must contain a C integer format like "%03d" (e.g. "frame%03d.png")' = has_c_integer_format(
+				file
+			)
+		)
 		function(expr, file, width, height, delay, res) {
 			pp_device(file, width = width / res, height = height / res, res = res)
 			eval(expr)
@@ -340,7 +344,12 @@ get_id_cfg <- function(df1, df2) {
 }
 
 get_tweenr_df <- function(df, ...) {
-	stopifnot(all(hasName(df, c("id", "piece_side", "rank", "suit", "x", "y"))))
+	stopifnot(
+		'`df` must have columns: "id", "piece_side", "rank", "suit", "x", "y"' = all(hasName(
+			df,
+			c("id", "piece_side", "rank", "suit", "x", "y")
+		))
+	)
 	if (!hasName(df, "alpha")) {
 		df$alpha <- 1
 	}

--- a/R/basicPieceGrob.R
+++ b/R/basicPieceGrob.R
@@ -165,7 +165,7 @@ makeContent.basic_piece_side <- function(x) {
 		col = opt$dm_color,
 		fontsize = opt$dm_fontsize,
 		fontfamily = opt$dm_fontfamily,
-		fontface = opt$ps_fontface
+		fontface = opt$dm_fontface
 	)
 	dm_grob <- textGrob(
 		opt$dm_text,

--- a/R/game_systems.R
+++ b/R/game_systems.R
@@ -876,7 +876,6 @@ chess <- function(font = "sans", cell_width = 1, color_list = color_list_fn()) {
 		grob_fn.s7.die_face = basicPieceGrobFn(fill_stroke = TRUE),
 		grob_fn.s8.bit_face = basicPieceGrobFn(fill_stroke = TRUE),
 		grob_fn.s8.die_face = basicPieceGrobFn(fill_stroke = TRUE),
-		# grob_fn.s6.bit_face = basicPieceGrob,
 		gridline_color.board_face = cb_suit_colors_impure,
 		gridline_color.board_back = cb_suit_colors_pure,
 		gridline_lex.board = 4,
@@ -1237,6 +1236,8 @@ shapes_cfg <- function(color_list = color_list_fn()) {
 
 reversi_piece <- function(cell_width = 1, color_list = color_list_fn()) {
 	shapes_top <- shapes_cfg(color_list)
+	# Reorder suit colors to their CMYK/RGB complements so each reversi piece has opposite-colored sides
+	# e.g. vermillion(1)<->cyan(7), black(2)<->white(6), green(3)<->magenta(8), blue(4)<->yellow(5)
 	color_list$suit_color <- color_list$suit_color[c(7L, 6L, 8L, 5L, 4L, 2L, 1L, 3L)]
 	shapes_bot <- shapes_cfg(color_list)
 	envir <- list(shapes_top = shapes_top, shapes_bot = shapes_bot)

--- a/R/pieceGrob-grid.R
+++ b/R/pieceGrob-grid.R
@@ -116,7 +116,10 @@ pieceGrobHelper <- function(
 	name = "",
 	bleed = FALSE
 ) {
-	stopifnot(isFALSE(bleed) || op_scale < 0.0001)
+	stopifnot(
+		'"bleed" and oblique projection ("op_scale") cannot be used together' = isFALSE(bleed) ||
+			op_scale < 0.0001
+	)
 	if (scale == 0 || alpha == 0) {
 		return(nullGrob())
 	}
@@ -246,7 +249,10 @@ pieceGrob <- function(
 	type = "normal",
 	bleed = FALSE
 ) {
-	stopifnot(!(bleed && op_scale > 0))
+	stopifnot(
+		'"bleed" and oblique projection ("op_scale") cannot be used together' = !(bleed &&
+			op_scale > 0)
+	)
 	if (any(piece_side == "preview_layout")) {
 		warn(
 			paste0(

--- a/R/pp_cfg.R
+++ b/R/pp_cfg.R
@@ -712,7 +712,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				private$cfg$annotation_color %||% "black"
 			} else {
-				stopifnot(is.character(value))
+				stopifnot("`annotation_color` must be a character string" = is.character(value))
 				private$cfg$annotation_color <- value
 			}
 		},
@@ -762,7 +762,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				private$cfg$copyright
 			} else {
-				stopifnot(is.character(value))
+				stopifnot("`copyright` must be a character string" = is.character(value))
 				private$cfg$copyright <- value
 			}
 		},
@@ -770,7 +770,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				private$cfg$credit
 			} else {
-				stopifnot(is.character(value))
+				stopifnot("`credit` must be a character string" = is.character(value))
 				private$cfg$credit <- value
 			}
 		},
@@ -778,7 +778,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				private$cfg$description
 			} else {
-				stopifnot(is.character(value))
+				stopifnot("`description` must be a character string" = is.character(value))
 				private$cfg$description <- value
 			}
 		},
@@ -786,7 +786,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				private$cfg$die_arrangement %||% "counter_down"
 			} else {
-				stopifnot(is.character(value))
+				stopifnot("`die_arrangement` must be a character string" = is.character(value))
 				private$cfg$die_arrangement <- value
 			}
 		},
@@ -801,7 +801,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				self$has_coins && self$has_tiles && self$has_pawns && self$has_dice
 			} else {
-				stopifnot(is.logical(value))
+				stopifnot("`has_piecepack` must be a logical value" = is.logical(value))
 				self$has_coins <- value
 				self$has_tiles <- value
 				self$has_pawns <- value
@@ -840,7 +840,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				private$cfg$spdx_id
 			} else {
-				stopifnot(is.character(value))
+				stopifnot("`spdx_id` must be a character string" = is.character(value))
 				check_spdx_id(value)
 				private$cfg$spdx_id <- value
 			}
@@ -849,7 +849,7 @@ Config <- R6Class(
 			if (missing(value)) {
 				private$cfg$title
 			} else {
-				stopifnot(is.character(value))
+				stopifnot("`title` must be a character string" = is.character(value))
 				private$cfg$title <- value
 			}
 		}

--- a/R/render_piece.R
+++ b/R/render_piece.R
@@ -92,7 +92,7 @@ render_piece <- function(
 	xbreaks = NULL,
 	ybreaks = NULL
 ) {
-	stopifnot(is.null(dev) || is.function(dev))
+	stopifnot("`dev` must be NULL or a function" = is.null(dev) || is.function(dev))
 	image <- match.arg(image)
 	if (image == "NULL") {
 		image <- NULL

--- a/R/render_piece.R
+++ b/R/render_piece.R
@@ -18,7 +18,7 @@
 #' @param xoffset Number to add to the `x` column in `df`.  Inferred by default.
 #' @param yoffset Number to add to the `y` column in `df`.  Inferred by default.
 #' @param annotate If `TRUE` or `"algebraic"` annotate the plot
-#'                 with \dQuote{algrebraic} coordinates,
+#'                 with \dQuote{algebraic} coordinates,
 #'                 if `FALSE` or `"none"` don't annotate,
 #'                 if `"cartesian"` annotate the plot with \dQuote{cartesian} coordinates.
 #' @param annotation_scale Multiplicative factor that scales (stretches) any annotation coordinates.
@@ -58,7 +58,7 @@
 #'    grid::grid.newpage()
 #'    render_piece(df, open_device = FALSE,
 #'                 op_scale = 0.5, trans = op_transform,
-#'                 annotate = "algrebraic")
+#'                 annotate = "algebraic")
 #'  }
 #'  \dontrun{# May take more than 5 seconds on CRAN servers
 #'  if (require(rayvertex)) {

--- a/R/render_piece.R
+++ b/R/render_piece.R
@@ -227,8 +227,10 @@ plot_fn_helper <- function(
 	} else if (identical(.f, piece3d)) {
 		assert_suggested("rgl")
 		if (Sys.which("wmctrl") != "") {
-			cmd <- paste0("wmctrl -r RGL -e 0,-1,-1,", ceiling(width), ",", ceiling(height))
-			system(cmd)
+			system2(
+				"wmctrl",
+				c("-r", "RGL", "-e", paste0("0,-1,-1,", ceiling(width), ",", ceiling(height)))
+			)
 		}
 		f <- tempfile(fileext = ".png")
 		function(df, ..., scale = 1) {

--- a/R/save_piece_images.R
+++ b/R/save_piece_images.R
@@ -119,7 +119,7 @@ save_piece_images <- function(
 	opt <- options(piecepackr.op_scale = 0)
 	on.exit(options(opt), add = TRUE)
 
-	stopifnot(dir.exists(directory))
+	stopifnot("`directory` must be an existing directory" = dir.exists(directory))
 
 	for (f in format) {
 		for (a in angle) {

--- a/R/save_piece_obj.R
+++ b/R/save_piece_obj.R
@@ -77,7 +77,7 @@ save_piece_obj <- function(
 		filename <- sprintf(filename, seq_along(filename))
 	}
 	filename <- normalizePath(filename, mustWork = FALSE)
-	stopifnot(!anyDuplicated(filename))
+	stopifnot("`filename` must not contain duplicates" = !anyDuplicated(filename))
 
 	l <- lapply(seq.int(nn), function(i) {
 		df <- save_piece_obj_helper(

--- a/R/save_piece_obj.R
+++ b/R/save_piece_obj.R
@@ -172,7 +172,7 @@ write_mtl <- function(mtl_filename, png_filename) {
 	writeLines(c("newmtl material_0", paste("map_Kd", png_filename)), mtl_filename)
 }
 
-# 1,2,3,4 -> 1,4,3,2
+# 1,2,3,4 -> 1,4,3,2: reverses winding order so the face normal points away from viewer (required for back-face culling)
 rev_shift <- function(x) c(x[1], rev(x[-1]))
 
 # (2-sided token) rotation matrix to move from "face" to `side`
@@ -256,6 +256,7 @@ save_2s_obj <- function(
 	)
 	xy_npc <- as_coord2d(shape$npc_coords)
 	xy_npc_back <- as_coord2d(back$npc_coords)
+	# Texture atlas: [face 2.5%-42.5%] [edge 48%-52%] [back 57.5%-97.5%]
 	xy_vt_f <- xy_npc$scale(0.4, 1)$translate(as_coord2d(0.025, 0))
 	xy_vt_b <- xy_npc_back$scale(0.4, 1)$translate(as_coord2d(0.575, 0))
 	xy_vt_e <- list(x = c(0.52, 0.48, 0.48, 0.52), y = c(0, 0, 1, 1))
@@ -265,7 +266,7 @@ save_2s_obj <- function(
 	nv <- length(xyz) / 2
 	f <- list()
 	f[[1]] <- list(v = seq(nv), vt = seq(nv)) # top
-	#### #217 "coin_arrangement"
+	#### #217: respect coin_arrangement config when orienting the back face
 	f[[2]] <- list(v = rev_shift(nv + seq(nv)), vt = rev_shift(nv + seq(nv))) # bottom
 	# sides
 	for (i in seq(nv)) {
@@ -980,7 +981,7 @@ save_holed_board_obj_fn <- function(nrows = 4L, ncols = 4L, margin = 0) {
 	force(nrows)
 	force(ncols)
 	force(margin)
-	stopifnot(nrows == ncols)
+	stopifnot("nrows must equal ncols for holed board geometry" = nrows == ncols)
 	function(
 		piece_side = "tile_face",
 		suit = 1,

--- a/R/save_print_and_play.R
+++ b/R/save_print_and_play.R
@@ -71,7 +71,7 @@ save_print_and_play <- function(
 	opt <- options(piecepackr.op_scale = 0)
 	on.exit(options(opt), add = TRUE)
 
-	stopifnot(is.null(dev) || is.function(dev))
+	stopifnot("`dev` must be NULL or a function" = is.null(dev) || is.function(dev))
 	size <- match.arg(size)
 	if (size == "4x6") {
 		warn(

--- a/R/utils-composite.R
+++ b/R/utils-composite.R
@@ -74,7 +74,7 @@ CompositePiece <- R6Class(
 				filename <- gsub(paste0("\\.", ext, "$"), paste0("_%03d.", ext), filename)
 				filename <- rep(filename, length.out = nrow(df))
 				filename <- sprintf(filename, seq_along(filename))
-				stopifnot(!anyDuplicated(filename))
+				stopifnot("`filename` must not contain duplicates" = !anyDuplicated(filename))
 				df$filename <- filename
 				l <- pmap_piece(
 					df,

--- a/man/render_piece.Rd
+++ b/man/render_piece.Rd
@@ -57,7 +57,7 @@ in which case it either uses the current graphics device or opens a new device
 \item{yoffset}{Number to add to the \code{y} column in \code{df}.  Inferred by default.}
 
 \item{annotate}{If \code{TRUE} or \code{"algebraic"} annotate the plot
-with \dQuote{algrebraic} coordinates,
+with \dQuote{algebraic} coordinates,
 if \code{FALSE} or \code{"none"} don't annotate,
 if \code{"cartesian"} annotate the plot with \dQuote{cartesian} coordinates.}
 
@@ -110,7 +110,7 @@ apply axes offsets, annotate coordinates, and set up \code{rayrender} / \code{ra
    grid::grid.newpage()
    render_piece(df, open_device = FALSE,
                 op_scale = 0.5, trans = op_transform,
-                annotate = "algrebraic")
+                annotate = "algebraic")
  }
  \dontrun{# May take more than 5 seconds on CRAN servers
  if (require(rayvertex)) {

--- a/tests/testthat/_snaps/options.md
+++ b/tests/testthat/_snaps/options.md
@@ -1,0 +1,8 @@
+# pp_cfg querying variables work as expected
+
+    Code
+      cfg$has_piecepack <- 3
+    Condition
+      Error:
+      ! `has_piecepack` must be a logical value
+

--- a/tests/testthat/_snaps/pieceGrob.md
+++ b/tests/testthat/_snaps/pieceGrob.md
@@ -6,6 +6,14 @@
       Warning:
       `size = "4x6"` is deprecated.
 
+# `save_piece_images()` works as expected
+
+    Code
+      save_piece_images(cfg_default, directory)
+    Condition
+      Error in `save_piece_images()`:
+      ! `directory` must be an existing directory
+
 # deprecated 'preview_layout' component warning
 
     Code

--- a/tests/testthat/_snaps/pieceGrob/coin-face-r4italic.svg
+++ b/tests/testthat/_snaps/pieceGrob/coin-face-r4italic.svg
@@ -20,7 +20,7 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <circle cx='360.00' cy='288.00' r='27.00' style='stroke-width: 0.75; stroke: none; fill: #FFFFFF;' />
 <text x='360.00' y='297.63' text-anchor='middle' style='font-size: 28.00px; font-style: italic; fill: #E69F00; font-family: sans;' textLength='15.57px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='360.00' y='273.04' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #E69F00; font-family: sans;' textLength='7.25px' lengthAdjust='spacingAndGlyphs'>●</text>
+<text x='360.00' y='273.04' text-anchor='middle' style='font-size: 12.00px; fill: #E69F00; font-family: sans;' textLength='7.25px' lengthAdjust='spacingAndGlyphs'>●</text>
 <circle cx='360.00' cy='288.00' r='27.00' style='stroke-width: 0.75; stroke: #BEBEBE;' />
 </g>
 </svg>

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -174,7 +174,7 @@ test_that("pp_cfg querying variables work as expected", {
 	expect_false(cfg$has_saucers)
 	expect_false(cfg$has_pyramids)
 	expect_false(cfg$has_matchsticks)
-	expect_error(cfg$has_piecepack <- 3, "is.logical\\(value)\\ is not TRUE")
+	expect_snapshot(error = TRUE, cfg$has_piecepack <- 3)
 
 	expect_true(cfg$cache_grob)
 	cfg$cache_grob <- FALSE

--- a/tests/testthat/test-pieceGrob.R
+++ b/tests/testthat/test-pieceGrob.R
@@ -106,7 +106,7 @@ test_that("`save_piece_images()` works as expected", {
 	current_dev <- grDevices::dev.cur()
 	expect_error(save_piece_images(cfg_default, directory), "dir.exists\\(directory\\) is not TRUE")
 	expect_error(grid.piece("tile_back", cfg = cfg), "Couldn't find suitable")
-	grDevices::dev.off()
+	suppressWarnings(grDevices::dev.off())
 	if (current_dev > 1) {
 		grDevices::dev.set(current_dev)
 	}
@@ -147,7 +147,7 @@ test_that("no regressions in figures", {
 		tmpfile <- tempfile(fileext = ".svg")
 		on.exit(unlink(tmpfile))
 		svg(tmpfile)
-		on.exit(dev.off(), add = TRUE)
+		on.exit(suppressWarnings(dev.off()), add = TRUE)
 		grid.piece(..., default.units = "npc")
 	}
 	# tile back

--- a/tests/testthat/test-pieceGrob.R
+++ b/tests/testthat/test-pieceGrob.R
@@ -104,7 +104,7 @@ test_that("`save_piece_images()` works as expected", {
 	}
 
 	current_dev <- grDevices::dev.cur()
-	expect_error(save_piece_images(cfg_default, directory), "dir.exists\\(directory\\) is not TRUE")
+	expect_snapshot(error = TRUE, save_piece_images(cfg_default, directory))
 	expect_error(grid.piece("tile_back", cfg = cfg), "Couldn't find suitable")
 	suppressWarnings(grDevices::dev.off())
 	if (current_dev > 1) {

--- a/tests/testthat/test-pp_shape.R
+++ b/tests/testthat/test-pp_shape.R
@@ -8,7 +8,7 @@ test_that("pp_shape() works as expected", {
 		grid.draw(circle$hexlines(gp = gpar(col = "yellow")))
 	})
 	unlink(pdf_file)
-	dev.off()
+	suppressWarnings(grDevices::dev.off())
 	if (current_dev > 1) {
 		grDevices::dev.set(current_dev)
 	}


### PR DESCRIPTION
- **fix(basicPieceGrob): Use dm_fontface for directional mark grob**
  The directional mark gpar block was incorrectly using opt$ps_fontface
  instead of opt$dm_fontface, causing the primary symbol's font style
  to bleed into the directional mark.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **fix(render_piece): Fix "algrebraic" typo in docs and example**
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **refactor(render_piece): Replace system() with system2()**
  Separates the command from its arguments, avoiding shell-quoting issues.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **tests: Suppress "Killing locked device" warning from R 4.6**
  R 4.6 emits a warning when dev.off() is called on a device left locked
  by an interrupted draw operation (e.g. an expected error mid-render).
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **refactor(pp_cfg): Add informative messages to stopifnot() calls**
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **tests(pp_cfg): Update has_piecepack error test to use expect_snapshot()**
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **refactor(save_piece_obj): Add clarifying comments**
  - Document texture atlas layout in save_2s_obj()
  - Clarify rev_shift() reverses winding order for back-face culling
  - Clarify #### #217 is a known TODO
  - Add informative message to stopifnot() in save_holed_board_obj_fn()
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **refactor(game_systems): Remove dead commented code; document reversi color mapping**
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **refactor: Add informative messages to stopifnot() calls in user-facing functions**
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  