### PR TITLE
fix(has_font): Strip all non-alphanumeric characters when comparing font names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Encoding: UTF-8
 Package: piecepackr
 Type: Package
 Title: Board Game Graphics
-Version: 1.16.2-3
+Version: 1.16.2-4
 Description: Functions to make board game graphics with the 'ggplot2', 'grid', 'rayrender', 'rayvertex', and 'rgl' packages.  Specializes in game diagrams, animations, and "Print & Play" layouts for the 'piecepack' <https://www.ludism.org/ppwiki> but can make graphics for other board game systems.  Includes configurations for several public domain game systems such as checkers, (double-18) dominoes, go, 'piecepack', playing cards, etc.
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ Bug fixes and minor improvements
 
 * `basicPieceGrob()` now correctly uses `dm_fontface` (instead of `ps_fontface`) when drawing the directional mark grob.
 
+* `has_font()` no longer returns `FALSE` for installed fonts whose family name contains characters (such as hyphens) that don't appear in its resolved font file's basename.
+
 * `"pawn_left"` and `"pawn_right"` are now drawn in "portrait" mode instead of "landscape" mode.
 
 piecepackr 1.16.1

--- a/R/utils-font.R
+++ b/R/utils-font.R
@@ -107,7 +107,7 @@ has_font <- function(font) {
 }
 
 simplify_font <- function(font) {
-	tolower(gsub(" ", "", font))
+	tolower(gsub("[^[:alnum:]]", "", font))
 }
 
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -6,6 +6,8 @@ expect_equal(to_r(0, 1), 1)
 f <- function(x) assert_suggested("imaginaryPackage")
 expect_error(f(), "You need to install the suggested package")
 
+expect_true(grepl(simplify_font("Dotaro Ranks"), simplify_font("dotaro-ranks.ttf")))
+
 skip_on_cran()
 skip_if_not_installed("pdftools")
 skip_if(!capabilities("cairo"))


### PR DESCRIPTION
Family names containing hyphens (e.g. "Dotaro Ranks" resolving to
"dotaro-ranks.ttf") previously failed to match since only spaces were
stripped before comparison, causing false negatives for installed fonts.
